### PR TITLE
(MAINT) Add fleshed out example content

### DIFF
--- a/content/books/iron-flax-bone/chapters/1/index.mdx
+++ b/content/books/iron-flax-bone/chapters/1/index.mdx
@@ -5,3 +5,14 @@ last-updated: 2020-07-13
 ---
 
 # Iron, Flax, & Bone
+
+_Pentola is a highly lethal world where what you believe and do is what you become.
+Explore a city of incredible magic and unending intrigue above catacombs filled with ancient horrors
+locked away before an apocalypse hundreds of years in the past.
+Take power, become rich, explore the lost city, or sing away the demons from your gondola._
+
+**In Pentola, you are what you choose to become.**
+
+_Iron, Flax, & Bone_ is a lightweight tabletop rpg that requires one twelve-sided die (a d12), a writing utensil, these rules, and a couple friends.
+
+One player is the referee (ref): they facilitate the game and take on running the world.

--- a/content/books/iron-flax-bone/chapters/2/index.mdx
+++ b/content/books/iron-flax-bone/chapters/2/index.mdx
@@ -1,0 +1,110 @@
+---
+slug: characters
+title: Characters
+last-updated: 2020-07-13
+---
+
+<Clip id="dweomers">
+
+## Characteristics
+
+</Clip>
+
++ **Iron** represents force of will, presence, and metaphysical aptitude.
++ **Flax** represents mental prowess and training, including knowledge and intuition.
++ **Bone** represents physical prowess and training, including strength, agility, toughness, etc.
+
+Characteristics may never rise above `12`, any overage is wasted/ineffective.
+
+At creation, distribute 20 points between your three stats, none of which can start lower than 3 or higher than 8.
+
+<!-- TODO: Random characteristics generator -->
+
+<Clip id="familiarities">
+
+## Familiarities
+
+</Clip>
+
+Characters who are _familiar_ with something related to a particular task roll with advantage when trying it.
+They might be familiar with Medicine, the Gondolieri, Whittling, the Tideriser District, the _Web_ [dweomer](), or anything else.
+
+At creation, choose 6 familiarities.
+
+<!-- TODO: Random familiarity selector -->
+
+<Clip id="items">
+
+## Items
+
+</Clip>
+
+You can _carry_ up to 12 items but keep as many as you please wherever you consider safe.
+
+At creation, choose any six items between tools, kits, weapons, and armor.
+
+<!-- TODO: Random equipment selector -->
+
+<Clip id="tools">
+
+### Tools
+
+</Clip>
+
+Tools assist in performing specific tasks.
+Without them, some tasks can only be tried at disadvantage or maybe even not at all.
+Particularly excellent tools may grant advantage at a task.
+
+Some items perform the action themselves (such as [using a matrix]() to apply a [dweomer](../3#section-dweomers)) and have their own rating.
+In these cases, roll against the item's rating to determine success instead of the character's characteristic.
+
+<!-- TODO: Tool list -->
+
+<Clip id="kits">
+
+### Kits
+
+</Clip>
+
+Kits are consumable items needed for a broad set of tasks—herbalism, medicine, spelunking, etc—any time you need a consumable related to the kit, you have it.
+Mark next to your kit after each use.
+Kits always start with `12` uses.
+
+<!-- TODO: Kit list -->
+
+<Clip id="weapons">
+
+### Weapons
+
+</Clip>
+
+Successfully attacking someone with your weapon inflicts a hit—different enemies can sustain one or more hits.
+Unless they're [magic](), weapons are treated as basically the same except where there's in-fiction differences that are meaningful (eg, reach with a spear or axes being more useful at chopping into doors).
+
+<!-- TODO: Weapon list -->
+
+<Clip id="armo">
+
+### Armor
+
+</Clip>
+
+If wearing armor, roll a `d12` whenever you are hit (except if the hit was a _triumph_):
+
++ Light armor saves you from a hit on a `4`, `8`, or `12`.
++ Medium armor saves you from a hit on a `3`, `6`, `9`, or `12`.
++ Heavy armor saves you from a hit on any even number.
+
+<!-- TODO: Armor list -->
+
+<Clip id="ambitions">
+
+## Ambitions
+
+</Clip>
+At the beginning of play, choose one ambition your character is driven to fulfill.
+You may have up to two active ambitions at any time.
+
+Whenever you complete an ambition, add one familiarity which you gained in the service of that ambition.
+
+<!-- TODO: Ambition list -->

--- a/content/books/iron-flax-bone/chapters/3/index.mdx
+++ b/content/books/iron-flax-bone/chapters/3/index.mdx
@@ -1,0 +1,53 @@
+---
+slug: crafting
+title: "The Craft"
+last-updated: 2020-07-13
+---
+
+Magic in Pentola is known as the Craft and those who dedicate themselves to it as Crafters.
+
+<Clip id="dweomers">
+
+## Dweomers
+
+</Clip>
+
+Dweomers are the formulae by which Pentolans apply magic onto their world.
+You may apply any dweomer you have a copy of slowly, in a ritual, taking 10 minutes per magnitude.
+
+If you are _familiar_ with a dweomer, you may attempt to apply it from memory.
+If applying it as an _action_, make a **Flax** test;
+if a hostile creature or person is close to you, test with disadvantage.
+
+Whether or not you're _familiar_ with a dweomer, you may try to apply it as a _ritual_, provided you have a copy of it on you.
+If applying it as a _ritual_, make a **Flax** test with advantage.
+
+Start play with any one dweomer memorized.
+
+<!-- TODO: List of dweomers, random selector -->
+
+<Clip id="magic-items">
+
+## Magic Items
+
+</Clip>
+
+Magic items are as common as masterwork items in Pentola _because_ they're the same thing—a true artisan can't help but make magic items when they do their work.
+
+Mostly magic items do not have direct numeric impacts on the game, though they absolutely do have weird or interesting effects and/or count you as being familiar for one or more tasks.
+
+<!-- TODO: random magic item generator -->
+
+<Clip id="matrices">
+
+### Matrices
+
+</Clip>
+
+One way to apply a dweomer as an action more reliably is to use a _matrix_, a special device for applying a specific dweomer.
+
+Each matrix has it's own rating between `2-12`.
+This rating is only for the purposes of opposed tests;
+they are always automatically successful at applying a dweomer.
+After each use, roll a `d12`;
+unless the result is _over_ the matrix's rating, reduce its rating by one.

--- a/content/books/iron-flax-bone/chapters/4/index.mdx
+++ b/content/books/iron-flax-bone/chapters/4/index.mdx
@@ -1,0 +1,117 @@
+---
+slug: playing
+title: Actions & Playing
+last-updated: 2020-07-13
+---
+
+<Clip id="tests-intent-approach">
+
+## Tests, Intent & Approach
+
+</Clip>
+
+1. The player declares their character's _intent_—what outcome they want from their action.
+2. Once the _intent_ is known, the player must explain their character's _approach_—how thecharacter will attempt to realize their _intent_ through action.
+3. Once the _intent_ and _approach_ are known the ref is then—and **only then**—able to adjudicate the action, deciding first if a test is necessary, then which characteristic is most relevant based on the _intent_ and _approach_.
+   A test is necessary only under the following conditions:
+   1. The action as defined by the _intent_ and _approach_ together **can fail**.
+   1. The action as defined by the _intent_ and _approach_ together **can succeed**.
+   1. Failure has **meaningful consequences**.
+
+When a test is called for, the player should roll a `d12` against the specified characteristic:
+
++ A result lower than the characteristic is a _success_.
++ A result equal to the characteristic is a _triumph_.
++ A result above the characteristic is a _failure_.
+
+For especially easy or hard tasks, the ref may impose advantage or disadvantage on the roll;
+in which case, roll twice and take the _better_ result or _worse_ result respectively.
+
+A character may aid or interfere with another character’s test, granting advantage or imposing disadvantage respectively.
+
+When two or more characters oppose each other, such as in an argument, all roll.
+The character that **rolls highest without failing wins**.
+If all fail, the highest roll wins.
+In ties, the player wins.
+In ties between players, roll again between the tied parties only.
+
+<!-- TODO: Video tutorial -->
+
+<Clip id="action-time">
+
+## Action Time
+
+</Clip>
+
+When it is useful to break down time into discrete chunks—during chases, fights, disasters, whatever—it breaks down into **moments** roughly `3` seconds long.
+
+Characters can take one _action_ and one _reaction_ each moment without penalty.
+They may **take an additional** _action_ or _reaction_ but make all tests at disadvantage or forego either their _action_ or _reaction_ to test the other with advantage.
+
+_Actions_ include, but are not limited to:
+
++ making an attack
++ moving nearby
++ applying a dweomer
++ throwing a grappling hook
++ drinking a potion
++ using kit or tool
+
+_Reactions_ include, but are not limited to, the following:
+
++ parrying
++ blocking
++ dodging
++ interfering with or aiding another action.
+
+During action time use _Declare Up, Adjudicate Down_ (**DUAD**):
+
+1. Everyone involved makes an opposed **Flax** test, noting their result and noting whether they triumphed, succeeded, or failed.
+1. Actions and reactions are **declared from worst to best**--any reactions declared against an earlier action have advantage.
+1. Action tests are **made in reverse of declaration**, last declared action being adjudicated first, reactions occurring as appropriate.
+
+<!-- TODO: Video tutorial -->
+
+<Clip id="combat-reactions">
+
+## Combat Reactions
+
+</Clip>
+
+Each of the combat reactions has particular tradeoffs:
+
++ **Blocking** tests are made with advantage, sacrificing your shield to prevent injury.
++ **Parrying** tests bat aside your opponents weapon, acting like light armor if you are unarmored or allowing you to re-roll your armor save otherwise.
++ **Dodging** tests are made with disadvantage but negate injury if successful.
+
+<Clip id="injury-scarring-death">
+
+## Injury, Scarring, and Death
+
+</Clip>
+
+Combat is deadly and best avoided.
+Characters can be hit `3` times before their luck runs out and they **Face Death**, making a test against **Bone**:
+
++ **Triumph:** Character gains a **cool scar**.
++ **Success:** Character gains a **wound**.
++ **Failure:** Character gains a **terrible scar** and **2 wounds**.
+
+Scars come in two flavors, _cool_ and _terrible_.
+_Cool scars_ grant the character advantage on relevant social tests, _terrible scars_ impose disadvantage.
+
+_Wounds_ permanently fill in one of the character's hit boxes, effectively reducing how many hits they can take in the future.
+
+<Clip id="distance">
+
+## Distance
+
+</Clip>
+
+Something is _close_ if you can reach out and touch it with no more than a few steps.
+
+Something is _near_ if you can walk to it within a few seconds—within about 30 ft.
+
+Something is _distant_ if it's further than nearby but still within about 150 ft.
+
+Something is _far_ if it's further than distant but still visible.


### PR DESCRIPTION
This commit adds the game text for the Iron, Flax, & Bone ruleset,
the expanded version of a slim pamphlet game.

There are numerous improvements to be made, but this brings the main
set of the example content onto the site.